### PR TITLE
Add unit tests for core climatology and stats functions

### DIFF
--- a/tests/test_climo_overlay.py
+++ b/tests/test_climo_overlay.py
@@ -1,0 +1,112 @@
+import os
+from pathlib import Path
+import sys
+
+import pandas as pd
+import numpy as np
+
+# Ensure repository root on sys.path for direct module imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import climo_overlay as co
+
+def make_sample_csv(tmp_path):
+    rows = []
+    for year in [2023, 2024]:
+        for hour in range(24):
+            date = f"08-01-{year}"
+            time = f"{hour:02d}:00"
+            rows.append({"Date": date, "Time (UTC)": time, "Air Temp (F)": float(hour)})
+    df = pd.DataFrame(rows)
+    csv_path = tmp_path / "sample.csv"
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+def test_build_monthly_climatology(tmp_path):
+    csv_path = make_sample_csv(tmp_path)
+    climo = co.build_monthly_climatology(str(csv_path), month=8, years=2, tz_name="UTC")
+    assert len(climo) == 24
+    assert list(climo["hour_local"]) == list(range(24))
+    assert climo.attrs["start_year"] == 2023
+    assert climo.attrs["latest_year"] == 2024
+    # mean should match the hour value
+    assert np.allclose(climo["mean"].to_numpy(), np.arange(24))
+
+
+def test_overlay_and_metrics(tmp_path):
+    test = pd.DataFrame({"hour": [0, 1, 2], "temp": [10.0, 20.0, 30.0]})
+    climo_interp = pd.DataFrame({
+        "hour": [0, 1, 2],
+        "mean": [5.0, 15.0, 25.0],
+        "std": [1.0, 1.0, 1.0],
+        "min": [0.0, 10.0, 20.0],
+        "max": [10.0, 20.0, 30.0],
+        "p05": [1.0, 11.0, 21.0],
+        "p25": [2.0, 12.0, 22.0],
+        "p75": [8.0, 18.0, 28.0],
+        "p95": [9.0, 19.0, 29.0],
+    })
+    outdir = tmp_path
+    co.overlay_and_metrics(test, climo_interp, str(outdir), title_prefix="TEST")
+    merged_csv = outdir / "merged_test_vs_climo.csv"
+    assert merged_csv.exists()
+    merged = pd.read_csv(merged_csv)
+    assert "residual" in merged.columns
+    assert np.allclose(merged["residual"].to_numpy(), [5, 5, 5])
+    assert (outdir / "overlay.png").exists()
+    assert (outdir / "residuals.png").exists()
+
+
+def test_infer_identifier_from_path():
+    assert co.infer_identifier_from_path("/tmp/KDLF_test.csv") == "KDLF"
+    # When fewer than four leading letters are present, the function returns the
+    # first four characters of the basename (which may include punctuation).
+    assert co.infer_identifier_from_path("/tmp/abc.csv") == "ABC."
+
+
+def test_plot_composite_mean_std(tmp_path):
+    df = pd.DataFrame({
+        "hour_local": [0, 1],
+        "KDLF_mean": [10.0, 20.0],
+        "KDLF_std": [1.0, 1.0],
+        "KDLF_p25": [9.0, 19.0],
+        "KDLF_p75": [11.0, 21.0],
+        "KDLF_p05": [8.0, 18.0],
+        "KDLF_p95": [12.0, 22.0],
+        "KEND_mean": [15.0, 25.0],
+        "KEND_std": [1.0, 1.0],
+        "KEND_p25": [14.0, 24.0],
+        "KEND_p75": [16.0, 26.0],
+        "KEND_p05": [13.0, 23.0],
+        "KEND_p95": [17.0, 27.0],
+    })
+    test_df = pd.DataFrame({"hour": [0, 1], "temp": [11.0, 21.0]})
+    out_png = tmp_path / "comp.png"
+    co.plot_composite_mean_std(df, str(out_png), test=test_df)
+    assert out_png.exists()
+
+
+def test_find_latest_station_csv(tmp_path):
+    d = tmp_path
+    (d / "KDLF_20200101.csv").write_text("a")
+    (d / "KDLF_20210101.csv").write_text("b")
+    latest = co.find_latest_station_csv(str(d), "KDLF")
+    assert latest.endswith("KDLF_20210101.csv")
+    assert co.find_latest_station_csv(str(d), "XXXX") is None
+
+
+def test_compute_per_year_hourly_means(tmp_path):
+    csv_path = make_sample_csv(tmp_path)
+    df, sy, ey = co.compute_per_year_hourly_means(str(csv_path), month=8, tz_name="UTC", years=2)
+    assert sy == 2023 and ey == 2024
+    assert df.shape == (48, 3)  # 24 hours * 2 years
+    # ensure each year appears
+    assert set(df["year"]) == {2023, 2024}
+
+
+def test_plot_per_year_means(tmp_path):
+    csv_path = make_sample_csv(tmp_path)
+    df, sy, ey = co.compute_per_year_hourly_means(str(csv_path), month=8, tz_name="UTC", years=2)
+    out_png = co.plot_per_year_means(df, ident="TEST", month=8, sy=sy, ey=ey, test_csv=None, outdir=str(tmp_path))
+    assert Path(out_png).exists()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,115 @@
+import os
+from pathlib import Path
+from datetime import datetime, timedelta
+import sys
+
+import numpy as np
+import pandas as pd
+
+# Ensure repository root on sys.path for direct module imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import stats
+
+
+def test_wilson_ci_basic():
+    (ci_low, ci_high), p = stats.wilson_ci(5, 10)
+    assert p == 0.5
+    assert ci_low < p < ci_high
+    assert np.isclose(ci_low, 0.2366, atol=1e-3)
+    assert np.isclose(ci_high, 0.7634, atol=1e-3)
+
+
+def test_parse_years_input():
+    years = stats.parse_years_input(["2015-2017", "2019,2021", "2022"])
+    assert years == [2015, 2016, 2017, 2019, 2021, 2022]
+
+
+def test_parse_utc_local():
+    dt = stats.parse_utc_local("01-02-2020", "12:00", "America/Chicago")
+    assert dt.tzinfo is not None
+    assert dt.hour == 6  # CST is UTC-6 in January
+
+
+def test_qc_filter_days(tmp_path):
+    rows = []
+    base = datetime(2020, 1, 1)
+    for h in range(24):
+        rows.append({"datetime_local": base + timedelta(hours=h), "Air Temp (F)": float(h)})
+    base2 = datetime(2020, 1, 2)
+    for h in range(24):
+        rows.append({"datetime_local": base2 + timedelta(hours=h), "Air Temp (F)": 0.0})
+    df = pd.DataFrame(rows)
+    filtered, keep_days, reasons = stats.qc_filter_days(df, 2.0, 2, 0.8, 24)
+    assert len(keep_days) == 1
+    assert base.date() in keep_days
+    assert base2.date() not in keep_days
+    assert base2.date() in reasons
+
+
+def test_resample_to_half_hour():
+    base = datetime(2020, 1, 1)
+    df = pd.DataFrame({
+        "datetime_local": [base, base + timedelta(hours=1), base + timedelta(hours=2)],
+        "Air Temp (F)": [0.0, 10.0, 20.0],
+    })
+    grid, daily = stats.resample_to_half_hour(df)
+    assert len(grid) == 48
+    assert base.date() in daily
+    vec = daily[base.date()]
+    assert len(vec) == 48
+    assert vec[0] == 0.0
+    assert vec[-1] == 20.0
+
+
+def test_plot_risk2_area_examples(tmp_path):
+    idx = pd.date_range("2020-01-01", periods=48, freq="H")
+    temps = [50.0] * 24 + [40.0] * 24
+    df = pd.DataFrame({"temp": temps}, index=idx)
+    boundary = np.array([45.0] * 24)
+    outfile = stats.plot_risk2_area_examples(df, boundary, "TEST", 1, tmp_path, theta_area=10.0)
+    assert Path(outfile).exists()
+
+
+def test_generate_case_study(tmp_path):
+    # Weather data for two days
+    rows = []
+    base = datetime(2020, 1, 1)
+    for day in range(2):
+        day_base = base + timedelta(days=day)
+        for h in range(24):
+            temp = 60 + 10 * np.sin(2 * np.pi * h / 24) + (10 if day == 0 else -10)
+            rows.append({"Date": day_base.strftime("%m-%d-%Y"),
+                         "Time (UTC)": f"{h:02d}:00",
+                         "Air Temp (F)": temp})
+    weather = pd.DataFrame(rows)
+    weather_csv = tmp_path / "weather.csv"
+    weather.to_csv(weather_csv, index=False)
+    # Boundary: constant 60°F at 0.5h increments
+    hours = np.arange(0, 24, 0.5)
+    boundary = pd.DataFrame({"hour": hours, "temp": [60.0] * len(hours)})
+    boundary_csv = tmp_path / "boundary.csv"
+    boundary.to_csv(boundary_csv, index=False)
+
+    outputs = stats.generate_case_study(
+        weather_file=str(weather_csv),
+        boundary_file=str(boundary_csv),
+        station="TEST",
+        month=1,
+        years=[2020],
+        tz_name="UTC",
+        risk2_window_hours=2.0,
+        risk2_area_thresh=10.0,
+        outdir=str(tmp_path),
+    )
+    assert Path(outputs.pdf).exists()
+    assert Path(outputs.csv_risk1).exists()
+    assert Path(outputs.csv_risk2).exists()
+    assert Path(outputs.plot_risk1_stacked).exists()
+    assert Path(outputs.plot_severity_hist).exists()
+    assert outputs.stats["n_days"] == 2
+
+
+def test_parse_months_input():
+    months = stats.parse_months_input(["7", "10-2", "5,6"])
+    assert months == [1, 2, 5, 6, 7, 10, 11, 12]


### PR DESCRIPTION
## Summary
- add tests for climatology utilities (building monthly climatology, overlays, composite plotting, station resolution, per-year means)
- add tests for stats utilities (Wilson CI, year/month parsing, UTC conversion, QC filtering, resampling, risk plotting, case study generation)

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a01412c004832e9d8385522cffdb4b